### PR TITLE
Make the package correctly installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,24 +14,20 @@ This Python project uses Poetry for dependency management. To get started:
 
 For detailed instructions on how to work with the code in this repo, check out [Getting Started with BallotLab · TrustTheVote-Project/BallotLab Wiki](https://github.com/TrustTheVote-Project/BallotLab/wiki/Getting-Started-with-BallotLab).
 
-Once you've set up the virtual environment with `poetry shell` you can run the Python app from the root of this repo:
+Once you've set up the virtual environment with `poetry shell` you can run the Python app using poetry run`:
 
 ```python
-python -m src.electos.ballotmaker --help        # display the CLI help text
-python -m src.electos.ballotmaker --version     # display the current version number
+poetry run ballotmaker --help        # display the CLI help text
+poetry run ballotmaker --version     # display the current version number
 ```
-
-**Important**: use the `-m` argument (`python -m`) to ensure Python can find all the local modules from the root directory.
 
 ## Running Tests
 
 After you've followed the steps above in **Getting Started**, you can also run the `pytest` suite with this command:
 
 ```python
-python -m pytest
+poetry run pytest
 ```
-
-Again, run that command from the root directory of this repo, using the `python -m` option.
 
 ## The Wiki
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Testing and prototyping code for BallotMaker, part of ElectOS Versa."
 authors = ["Neil Johnson <neil@cadent.com>"]
 license = "OSET Public License"
+packages = [
+    { include = "electos/ballotmaker", from = "src" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ mypy = "^0.950"
 pytest = "^7.1.2"
 pytest-cov = "^3.0.0"
 
+[tool.poetry.scripts]
+ballotmaker = 'electos.ballotmaker.cli:main'
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/electos/ballotmaker/__main__.py
+++ b/src/electos/ballotmaker/__main__.py
@@ -1,4 +1,3 @@
-## execute with 'python -m' to find this module
 from electos.ballotmaker import cli
 
 cli.app()

--- a/src/electos/ballotmaker/__main__.py
+++ b/src/electos/ballotmaker/__main__.py
@@ -1,4 +1,4 @@
 ## execute with 'python -m' to find this module
-from src.electos.ballotmaker import cli
+from electos.ballotmaker import cli
 
 cli.app()

--- a/src/electos/ballotmaker/cli.py
+++ b/src/electos/ballotmaker/cli.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 ## execute with 'python -m' to find this module
-from src.electos.ballotmaker import __version__
+from electos.ballotmaker import __version__
 
 PROGRAM_NAME = "BallotMaker"
 

--- a/src/electos/ballotmaker/cli.py
+++ b/src/electos/ballotmaker/cli.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import typer
 
-## execute with 'python -m' to find this module
 from electos.ballotmaker import __version__
 
 PROGRAM_NAME = "BallotMaker"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 from typer.testing import CliRunner
-from src.electos.ballotmaker import __version__, cli
+from electos.ballotmaker import __version__, cli
 
 runner = CliRunner()
 


### PR DESCRIPTION
Changes:
- Define the namespace package in `pyproject.toml` using the [`packages` directive](https://python-poetry.org/docs/pyproject/#packages). This makes the package properly installable so that `poetry install` uses the _installation_ environment for development, and `poetry build` will create a package that `pip` or `poetry` can use properly. Everything else follows from this [^1].
- Remove `src` from all import paths: the package name is `electos.ballotmaker`. Adding `src` is only needed because without the namespace package the PYTHONPATH isn't being set properly and the import starts at the root of the _source_ tree. This is incorrect because it will break once the code is executed outside the source tree - which is true in any installation. 
- Add a console script for `ballotmaker` to allow use `poetry run ballotmaker` instead of `python -m path.to.ballotmaker`. The latter can accidentally import a source package, while the former will not.
- Replace references to `python -m` with `poetry run` in the README.
   -  Note: I didn't add the details of the install to the README, but a properly installed package will not need either of those. Just `ballotmaker` will work. I've verified that this works, whether the installation is from Pip, Git, or using a wheel directly.

[^1]: For details see [Packaging a Python Library - the Structure](https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure)

