### PR TITLE
'poetry run ballotmaker' working properly.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pytest = "^7.1.2"
 pytest-cov = "^3.0.0"
 
 [tool.poetry.scripts]
-ballotmaker = 'electos.ballotmaker.cli:main'
+ballotmaker = 'electos.ballotmaker.cli:app'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/electos/ballotmaker/cli.py
+++ b/src/electos/ballotmaker/cli.py
@@ -24,9 +24,5 @@ def cli(
         raise typer.Exit()
 
 
-def main():
-    app()
-
-
 if __name__ == "__main__":
     app()

--- a/src/electos/ballotmaker/cli.py
+++ b/src/electos/ballotmaker/cli.py
@@ -13,7 +13,7 @@ app = typer.Typer(no_args_is_help=True)
 
 
 @app.command()
-def main(
+def cli(
     version: Optional[bool] = typer.Option(
         None, "--version", help="Print the version number."
     ),
@@ -22,6 +22,10 @@ def main(
     if version:
         typer.echo(f"{PROGRAM_NAME} version: {__version__.__version__}")
         raise typer.Exit()
+
+
+def main():
+    app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The packaging entry point ('main') can't be a command: Typer needs to process decorated commands explicitly ('app()'). This can only happen _after_ the entry point is called.

Fixes #15.