### PR TITLE
September ballot and human-readable IDs

### DIFF
--- a/src/electos/ballotmaker/ballots/contest_data.py
+++ b/src/electos/ballotmaker/ballots/contest_data.py
@@ -63,17 +63,20 @@ class CandidateData:
     _names: list = field(init=False, repr=False, default_factory=list)
     party: str = field(init=False)
     party_abbr: str = field(init=False)
-    write_in: bool = field(init=False)
+    is_write_in: bool = field(init=False)
     name: str = field(init=True, default="")
 
     def __post_init__(self):
         self.id = self._can_data.get("id", "")
         self._names = self._can_data.get("name", [])
-        _party_dict = self._can_data.get("party", {})
+        _party_list = self._can_data.get("party", [])
+        assert 0 <= len(_party_list) <= 1, \
+            f"Multiple parties for a slate/ticket not handled: {_party_list}"
+        _party_dict = _party_list[0] if len(_party_list) == 1 else {}
         self.party = _party_dict.get("name", "")
         self.party_abbr = _party_dict.get("abbreviation", "")
-        self.write_in = self._can_data.get("write_in")
-        if self.write_in:
+        self.is_write_in = self._can_data.get("is_write_in")
+        if self.is_write_in:
             self.name = "or write in:"
         else:
             for count, can_name in enumerate(self._names):

--- a/src/electos/ballotmaker/ballots/contest_layout.py
+++ b/src/electos/ballotmaker/ballots/contest_layout.py
@@ -184,7 +184,7 @@ class CandidateContestLayout:
                     " and ", "<br />and<br />"
                 )
             # add line for write ins
-            if candidate.write_in:
+            if candidate.is_write_in:
                 candidate.name += ("<br />" * 2) + ("_" * 20)
             contest_line = f"<b>{candidate.name}</b>"
             if candidate.party_abbr != "":

--- a/src/electos/ballotmaker/demo_data/spacetown_data.json
+++ b/src/electos/ballotmaker/demo_data/spacetown_data.json
@@ -3,7 +3,7 @@
     "contests": {
         "candidate": [
             {
-                "id": "recsoZy7vYhS3lbcK",
+                "id": "contest-potus",
                 "title": "President of the United States",
                 "type": "candidate",
                 "vote_type": "plurality",
@@ -11,7 +11,7 @@
                 "district": "United States of America",
                 "candidates": [
                     {
-                        "id": "recQK3J9IJq42hz2n",
+                        "id": "contest-potus--candidate-lepton",
                         "name": [
                             "Anthony Alpha",
                             "Betty Beta"
@@ -25,7 +25,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "reccUkUdEznfODgeL",
+                        "id": "contest-potus--candidate-hadron",
                         "name": [
                             "Gloria Gamma",
                             "David Delta"
@@ -39,7 +39,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recPod2L8VhwagiDl",
+                        "id": "contest-potus--candidate-write-in-1",
                         "name": [],
                         "party": [],
                         "is_write_in": true
@@ -47,7 +47,7 @@
                 ]
             },
             {
-                "id": "recthF6jdx5ybBNkC",
+                "id": "contest-gadget-county-school-board",
                 "title": "Gadget County School Board",
                 "type": "candidate",
                 "vote_type": "n-of-m",
@@ -55,7 +55,7 @@
                 "district": "Gadget County",
                 "candidates": [
                     {
-                        "id": "recJvikmG5MrUKzo1",
+                        "id": "contest-gadget-county-school-board--candidate-rosashawn-davis",
                         "name": [
                             "Rosashawn Davis"
                         ],
@@ -65,7 +65,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recigPkqYXXDJEaCE",
+                        "id": "contest-gadget-county-school-board--candidate-hector-gomez",
                         "name": [
                             "Hector Gomez"
                         ],
@@ -75,7 +75,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recbN7UUMaSuOYGQ6",
+                        "id": "contest-gadget-county-school-board--candidate-glavin-orotund",
                         "name": [
                             "Glavin Orotund"
                         ],
@@ -85,7 +85,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recbxvhKikHJNZYbq",
+                        "id": "contest-gadget-county-school-board--candidate-sally-smith",
                         "name": [
                             "Sally Smith"
                         ],
@@ -95,7 +95,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recvjB3rgfiicf0RP",
+                        "id": "contest-gadget-county-school-board--candidate-oliver-tsi",
                         "name": [
                             "Oliver Tsi"
                         ],
@@ -105,19 +105,19 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recYurH2CLY3SlYS8",
+                        "id": "contest-gadget-county-school-board--candidate-write-in-1",
                         "name": [],
                         "party": [],
                         "is_write_in": true
                     },
                     {
-                        "id": "recI5jfcXIsbAKytC",
+                        "id": "contest-gadget-county-school-board--candidate-write-in-2",
                         "name": [],
                         "party": [],
                         "is_write_in": true
                     },
                     {
-                        "id": "recn9m0o1em7gLahj",
+                        "id": "contest-gadget-county-school-board--candidate-write-in-3",
                         "name": [],
                         "party": [],
                         "is_write_in": true
@@ -125,7 +125,7 @@
                 ]
             },
             {
-                "id": "recIj8OmzqzzvnDbM",
+                "id": "contest-orbit-city-mayor",
                 "title": "Contest for Mayor of Orbit City",
                 "type": "candidate",
                 "vote_type": "plurality",
@@ -133,7 +133,7 @@
                 "district": "Orbit City",
                 "candidates": [
                     {
-                        "id": "recKD6dBvkNhEU4bg",
+                        "id": "contest-orbit-city-mayor--candidate-spencer-cogswell",
                         "name": [
                             "Spencer Cogswell"
                         ],
@@ -146,7 +146,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recTKcXLCzRvKB9U0",
+                        "id": "contest-orbit-city-mayor--candidate-cosmo-spacely",
                         "name": [
                             "Cosmo Spacely"
                         ],
@@ -159,7 +159,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recqq21kO6HWgpJZV",
+                        "id": "contest-orbit-city-mayor--candidate-write-in-1",
                         "name": [],
                         "party": [],
                         "is_write_in": true
@@ -167,7 +167,7 @@
                 ]
             },
             {
-                "id": "recXNb4zPrvC1m6Fr",
+                "id": "contest-spaceport-control-board",
                 "title": "Spaceport Control Board",
                 "type": "candidate",
                 "vote_type": "n-of-m",
@@ -175,7 +175,7 @@
                 "district": "Aldrin Space Transport District",
                 "candidates": [
                     {
-                        "id": "recBnJZEgCKAnfpNo",
+                        "id": "contest-spaceport-control-board--candidate-harlan-ellis",
                         "name": [
                             "Harlan Ellis"
                         ],
@@ -185,7 +185,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recwNuOnepWNGz67V",
+                        "id": "contest-spaceport-control-board--candidate-rudy-indexer",
                         "name": [
                             "Rudy Indexer"
                         ],
@@ -195,7 +195,7 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "recvYvTb9hWH7tptb",
+                        "id": "contest-spaceport-control-board--candidate-jane-jetson",
                         "name": [
                             "Jane Jetson"
                         ],
@@ -205,13 +205,13 @@
                         "is_write_in": false
                     },
                     {
-                        "id": "rec9Eev970VhohqKi",
+                        "id": "contest-spaceport-control-board--candidate-write-in-1",
                         "name": [],
                         "party": [],
                         "is_write_in": true
                     },
                     {
-                        "id": "recFiGYjGCIyk5LBe",
+                        "id": "contest-spaceport-control-board--candidate-write-in-2",
                         "name": [],
                         "party": [],
                         "is_write_in": true
@@ -221,34 +221,34 @@
         ],
         "ballot_measure": [
             {
-                "id": "recqPa7AeyufIfd6k",
+                "id": "ballot-measure-air-traffic-control-tax",
                 "title": "Air Traffic Control Tax Increase",
                 "type": "ballot measure",
                 "district": "Gadget County",
                 "choices": [
                     {
-                        "id": "recysACFx8cgwomBE",
+                        "id": "ballot-measure-air-traffic-control-tax--yes",
                         "choice": "Yes"
                     },
                     {
-                        "id": "recabXA9jzFYRmGXy",
+                        "id": "ballot-measure-air-traffic-control-tax--no",
                         "choice": "No"
                     }
                 ],
                 "text": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?"
             },
             {
-                "id": "recWjDBFeafCdklWq",
+                "id": "ballot-measure-helium-balloons",
                 "title": "Constitutional Amendment",
                 "type": "ballot measure",
                 "district": "The State of Farallon",
                 "choices": [
                     {
-                        "id": "rec7mVWjUH6fmDxig",
+                        "id": "ballot-measure-helium-balloons--yes",
                         "choice": "Yes"
                     },
                     {
-                        "id": "reccIHOhUfJgJkqS7",
+                        "id": "ballot-measure-helium-balloons--no",
                         "choice": "No"
                     }
                 ],

--- a/src/electos/ballotmaker/demo_data/spacetown_data.json
+++ b/src/electos/ballotmaker/demo_data/spacetown_data.json
@@ -3,178 +3,6 @@
     "contests": {
         "candidate": [
             {
-                "id": "recIj8OmzqzzvnDbM",
-                "title": "Contest for Mayor of Orbit City",
-                "type": "candidate",
-                "vote_type": "plurality",
-                "votes_allowed": 1,
-                "district": "Orbit City",
-                "candidates": [
-                    {
-                        "id": "recTKcXLCzRvKB9U0",
-                        "name": [
-                            "Cosmo Spacely"
-                        ],
-                        "party": [
-                            {
-                                "name": "The Lepton Party",
-                                "abbreviation": "LEP"
-                            }
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recKD6dBvkNhEU4bg",
-                        "name": [
-                            "Spencer Cogswell"
-                        ],
-                        "party": [
-                            {
-                                "name": "The Hadron Party of Farallon",
-                                "abbreviation": "HAD"
-                            }
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recqq21kO6HWgpJZV",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    }
-                ]
-            },
-            {
-                "id": "recXNb4zPrvC1m6Fr",
-                "title": "Spaceport Control Board",
-                "type": "candidate",
-                "vote_type": "n-of-m",
-                "votes_allowed": 2,
-                "district": "Aldrin Space Transport District",
-                "candidates": [
-                    {
-                        "id": "recvYvTb9hWH7tptb",
-                        "name": [
-                            "Jane Jetson"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recBnJZEgCKAnfpNo",
-                        "name": [
-                            "Harlan Ellis"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recwNuOnepWNGz67V",
-                        "name": [
-                            "Rudy Indexer"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "rec9Eev970VhohqKi",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    },
-                    {
-                        "id": "recFiGYjGCIyk5LBe",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    }
-                ]
-            },
-            {
-                "id": "recthF6jdx5ybBNkC",
-                "title": "Gadget County School Board",
-                "type": "candidate",
-                "vote_type": "n-of-m",
-                "votes_allowed": 4,
-                "district": "Gadget County",
-                "candidates": [
-                    {
-                        "id": "recbxvhKikHJNZYbq",
-                        "name": [
-                            "Sally Smith"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recigPkqYXXDJEaCE",
-                        "name": [
-                            "Hector Gomez"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recJvikmG5MrUKzo1",
-                        "name": [
-                            "Rosashawn Davis"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recvjB3rgfiicf0RP",
-                        "name": [
-                            "Oliver Tsi"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recbN7UUMaSuOYGQ6",
-                        "name": [
-                            "Glavin Orotund"
-                        ],
-                        "party": [
-                            {}
-                        ],
-                        "is_write_in": false
-                    },
-                    {
-                        "id": "recYurH2CLY3SlYS8",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    },
-                    {
-                        "id": "recI5jfcXIsbAKytC",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    },
-                    {
-                        "id": "recn9m0o1em7gLahj",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    }
-                ]
-            },
-            {
                 "id": "recsoZy7vYhS3lbcK",
                 "title": "President of the United States",
                 "type": "candidate",
@@ -182,12 +10,6 @@
                 "votes_allowed": 1,
                 "district": "United States of America",
                 "candidates": [
-                    {
-                        "id": "recPod2L8VhwagiDl",
-                        "name": [],
-                        "party": [],
-                        "is_write_in": true
-                    },
                     {
                         "id": "recQK3J9IJq42hz2n",
                         "name": [
@@ -215,6 +37,184 @@
                             }
                         ],
                         "is_write_in": false
+                    },
+                    {
+                        "id": "recPod2L8VhwagiDl",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
+                    }
+                ]
+            },
+            {
+                "id": "recthF6jdx5ybBNkC",
+                "title": "Gadget County School Board",
+                "type": "candidate",
+                "vote_type": "n-of-m",
+                "votes_allowed": 4,
+                "district": "Gadget County",
+                "candidates": [
+                    {
+                        "id": "recJvikmG5MrUKzo1",
+                        "name": [
+                            "Rosashawn Davis"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recigPkqYXXDJEaCE",
+                        "name": [
+                            "Hector Gomez"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recbN7UUMaSuOYGQ6",
+                        "name": [
+                            "Glavin Orotund"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recbxvhKikHJNZYbq",
+                        "name": [
+                            "Sally Smith"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recvjB3rgfiicf0RP",
+                        "name": [
+                            "Oliver Tsi"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recYurH2CLY3SlYS8",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
+                    },
+                    {
+                        "id": "recI5jfcXIsbAKytC",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
+                    },
+                    {
+                        "id": "recn9m0o1em7gLahj",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
+                    }
+                ]
+            },
+            {
+                "id": "recIj8OmzqzzvnDbM",
+                "title": "Contest for Mayor of Orbit City",
+                "type": "candidate",
+                "vote_type": "plurality",
+                "votes_allowed": 1,
+                "district": "Orbit City",
+                "candidates": [
+                    {
+                        "id": "recKD6dBvkNhEU4bg",
+                        "name": [
+                            "Spencer Cogswell"
+                        ],
+                        "party": [
+                            {
+                                "name": "The Hadron Party of Farallon",
+                                "abbreviation": "HAD"
+                            }
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recTKcXLCzRvKB9U0",
+                        "name": [
+                            "Cosmo Spacely"
+                        ],
+                        "party": [
+                            {
+                                "name": "The Lepton Party",
+                                "abbreviation": "LEP"
+                            }
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recqq21kO6HWgpJZV",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
+                    }
+                ]
+            },
+            {
+                "id": "recXNb4zPrvC1m6Fr",
+                "title": "Spaceport Control Board",
+                "type": "candidate",
+                "vote_type": "n-of-m",
+                "votes_allowed": 2,
+                "district": "Aldrin Space Transport District",
+                "candidates": [
+                    {
+                        "id": "recBnJZEgCKAnfpNo",
+                        "name": [
+                            "Harlan Ellis"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recwNuOnepWNGz67V",
+                        "name": [
+                            "Rudy Indexer"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "recvYvTb9hWH7tptb",
+                        "name": [
+                            "Jane Jetson"
+                        ],
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
+                    },
+                    {
+                        "id": "rec9Eev970VhohqKi",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
+                    },
+                    {
+                        "id": "recFiGYjGCIyk5LBe",
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     }
                 ]
             }
@@ -252,7 +252,7 @@
                         "choice": "No"
                     }
                 ],
-                "text": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
+                "text": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons.\nAll forms of helium are authorized for personal use or commercial balloon usage. Use of deuterium and tritium for energy generation will be licensed by the State commission. Use of deuterium and tritium for uncontrolled fusion reactions is strictly prohibited, and constitutes a Class A felony under State Criminal code section 4.222 K.\n"
             }
         ]
     }

--- a/src/electos/ballotmaker/demo_data/spacetown_data.json
+++ b/src/electos/ballotmaker/demo_data/spacetown_data.json
@@ -15,26 +15,32 @@
                         "name": [
                             "Cosmo Spacely"
                         ],
-                        "party": {
-                            "name": "The Lepton Party",
-                            "abbreviation": "LEP"
-                        },
-                        "write_in": false
+                        "party": [
+                            {
+                                "name": "The Lepton Party",
+                                "abbreviation": "LEP"
+                            }
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recKD6dBvkNhEU4bg",
                         "name": [
                             "Spencer Cogswell"
                         ],
-                        "party": {
-                            "name": "The Hadron Party of Farallon",
-                            "abbreviation": "HAD"
-                        },
-                        "write_in": false
+                        "party": [
+                            {
+                                "name": "The Hadron Party of Farallon",
+                                "abbreviation": "HAD"
+                            }
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recqq21kO6HWgpJZV",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     }
                 ]
             },
@@ -51,41 +57,42 @@
                         "name": [
                             "Jane Jetson"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recBnJZEgCKAnfpNo",
                         "name": [
                             "Harlan Ellis"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recwNuOnepWNGz67V",
                         "name": [
                             "Rudy Indexer"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "rec9Eev970VhohqKi",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     },
                     {
                         "id": "recFiGYjGCIyk5LBe",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     }
                 ]
             },
@@ -102,67 +109,68 @@
                         "name": [
                             "Sally Smith"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recigPkqYXXDJEaCE",
                         "name": [
                             "Hector Gomez"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recJvikmG5MrUKzo1",
                         "name": [
                             "Rosashawn Davis"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recvjB3rgfiicf0RP",
                         "name": [
                             "Oliver Tsi"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recbN7UUMaSuOYGQ6",
                         "name": [
                             "Glavin Orotund"
                         ],
-                        "party": {
-                            "name": "",
-                            "abbreviation": ""
-                        },
-                        "write_in": false
+                        "party": [
+                            {}
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "recYurH2CLY3SlYS8",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     },
                     {
                         "id": "recI5jfcXIsbAKytC",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     },
                     {
                         "id": "recn9m0o1em7gLahj",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     }
                 ]
             },
@@ -176,7 +184,9 @@
                 "candidates": [
                     {
                         "id": "recPod2L8VhwagiDl",
-                        "write_in": true
+                        "name": [],
+                        "party": [],
+                        "is_write_in": true
                     },
                     {
                         "id": "recQK3J9IJq42hz2n",
@@ -184,11 +194,13 @@
                             "Anthony Alpha",
                             "Betty Beta"
                         ],
-                        "party": {
-                            "name": "The Lepton Party",
-                            "abbreviation": "LEP"
-                        },
-                        "write_in": false
+                        "party": [
+                            {
+                                "name": "The Lepton Party",
+                                "abbreviation": "LEP"
+                            }
+                        ],
+                        "is_write_in": false
                     },
                     {
                         "id": "reccUkUdEznfODgeL",
@@ -196,33 +208,49 @@
                             "Gloria Gamma",
                             "David Delta"
                         ],
-                        "party": {
-                            "name": "The Hadron Party of Farallon",
-                            "abbreviation": "HAD"
-                        },
-                        "write_in": false
+                        "party": [
+                            {
+                                "name": "The Hadron Party of Farallon",
+                                "abbreviation": "HAD"
+                            }
+                        ],
+                        "is_write_in": false
                     }
                 ]
             }
         ],
         "ballot_measure": [
             {
+                "id": "recqPa7AeyufIfd6k",
                 "title": "Air Traffic Control Tax Increase",
                 "type": "ballot measure",
                 "district": "Gadget County",
                 "choices": [
-                    "Yes",
-                    "No"
+                    {
+                        "id": "recysACFx8cgwomBE",
+                        "choice": "Yes"
+                    },
+                    {
+                        "id": "recabXA9jzFYRmGXy",
+                        "choice": "No"
+                    }
                 ],
                 "text": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?"
             },
             {
+                "id": "recWjDBFeafCdklWq",
                 "title": "Constitutional Amendment",
                 "type": "ballot measure",
                 "district": "The State of Farallon",
                 "choices": [
-                    "Yes",
-                    "No"
+                    {
+                        "id": "rec7mVWjUH6fmDxig",
+                        "choice": "Yes"
+                    },
+                    {
+                        "id": "reccIHOhUfJgJkqS7",
+                        "choice": "No"
+                    }
                 ],
                 "text": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
             }

--- a/src/electos/ballotmaker/demo_data/spacetown_data.py
+++ b/src/electos/ballotmaker/demo_data/spacetown_data.py
@@ -9,19 +9,21 @@ can_con_4 = {
         {
             "id": "recTKcXLCzRvKB9U0",
             "name": ["Cosmo Spacely"],
-            "party": {"name": "The Lepton Party", "abbreviation": "LEP"},
-            "write_in": False,
+            "party": [{"name": "The Lepton Party", "abbreviation": "LEP"}],
+            "is_write_in": False,
         },
         {
             "id": "recKD6dBvkNhEU4bg",
             "name": ["Spencer Cogswell"],
-            "party": {
-                "name": "The Hadron Party of Farallon",
-                "abbreviation": "HAD",
-            },
-            "write_in": False,
+            "party": [
+                {
+                    "name": "The Hadron Party of Farallon",
+                    "abbreviation": "HAD",
+                },
+            ],
+            "is_write_in": False,
         },
-        {"id": "recqq21kO6HWgpJZV", "write_in": True},
+        {"id": "recqq21kO6HWgpJZV", "is_write_in": True},
     ],
 }
 
@@ -36,23 +38,23 @@ can_con_3 = {
         {
             "id": "recvYvTb9hWH7tptb",
             "name": ["Jane Jetson"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
         {
             "id": "recBnJZEgCKAnfpNo",
             "name": ["Harlan Ellis"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
         {
             "id": "recwNuOnepWNGz67V",
             "name": ["Rudy Indexer"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
-        {"id": "rec9Eev970VhohqKi", "write_in": True},
-        {"id": "recFiGYjGCIyk5LBe", "write_in": True},
+        {"id": "rec9Eev970VhohqKi", "is_write_in": True},
+        {"id": "recFiGYjGCIyk5LBe", "is_write_in": True},
     ],
 }
 
@@ -67,36 +69,36 @@ can_con_2 = {
         {
             "id": "recbxvhKikHJNZYbq",
             "name": ["Sally Smith"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
         {
             "id": "recigPkqYXXDJEaCE",
             "name": ["Hector Gomez"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
         {
             "id": "recJvikmG5MrUKzo1",
             "name": ["Rosashawn Davis"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
         {
             "id": "recvjB3rgfiicf0RP",
             "name": ["Oliver Tsi"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
         {
             "id": "recbN7UUMaSuOYGQ6",
             "name": ["Glavin Orotund"],
-            "party": {"name": "", "abbreviation": ""},
-            "write_in": False,
+            "party": [{"name": "", "abbreviation": ""}],
+            "is_write_in": False,
         },
-        {"id": "recYurH2CLY3SlYS8", "write_in": True},
-        {"id": "recI5jfcXIsbAKytC", "write_in": True},
-        {"id": "recn9m0o1em7gLahj", "write_in": True},
+        {"id": "recYurH2CLY3SlYS8", "is_write_in": True},
+        {"id": "recI5jfcXIsbAKytC", "is_write_in": True},
+        {"id": "recn9m0o1em7gLahj", "is_write_in": True},
     ],
 }
 
@@ -111,19 +113,21 @@ can_con_1 = {
         {
             "id": "recQK3J9IJq42hz2n",
             "name": ["Anthony Alpha", "Betty Beta"],
-            "party": {"name": "The Lepton Party", "abbreviation": "LEP"},
-            "write_in": False,
+            "party": [{"name": "The Lepton Party", "abbreviation": "LEP"}],
+            "is_write_in": False,
         },
         {
             "id": "reccUkUdEznfODgeL",
             "name": ["Gloria Gamma", "David Delta"],
-            "party": {
-                "name": "The Hadron Party of Farallon",
-                "abbreviation": "HAD",
-            },
-            "write_in": False,
+            "party": [
+                {
+                    "name": "The Hadron Party of Farallon",
+                    "abbreviation": "HAD",
+                },
+            ],
+            "is_write_in": False,
         },
-        {"id": "recPod2L8VhwagiDl", "write_in": True},
+        {"id": "recPod2L8VhwagiDl", "is_write_in": True},
     ],
 }
 


### PR DESCRIPTION
Use the [September test case](https://github.com/TrustTheVote-Project/NIST-1500-100-103-examples/blob/main/test_cases/september_test_case.json) to get a conventional order for contests and candidate selections.

- The order matches the ballot by default:
  - Federal races before county before local
  - Candidates before ballot measures
  - Candidate selections before write-ins
- All contests and contest selections have IDs

Also adds human-readable IDs in the last change. As we've discussed this is only intended to make debugging easier, not a formal proposal of a human-readable ID scheme.